### PR TITLE
bugfix: solution to screw tilt adjustment readout jumps issue

### DIFF
--- a/probe_eddy_ng.py
+++ b/probe_eddy_ng.py
@@ -2585,7 +2585,7 @@ class ProbeEddyScanningProbe:
 
         # not sure I need this wait_moves, need to understand what position
         # get_position returns
-        th.dwell(self._sample_time_delay)
+        th.dwell(self._sample_time_delay + self._sample_time)
         th.wait_moves()
 
         th_pos = th.get_position()


### PR DESCRIPTION
When reviewing the `Klipper` `probe` code and Eddy`s code by `Bigtreetech` I have found a small difference between the logic, which I correct here.
I also provide the solution to read in the `SCREWS_TILT_CALCULATE` command, the difference between the previous code is that now it keeps a few seconds more on each screw and can better measure the height of screws.
