### PR TITLE
Add Temperature Profile Support

### DIFF
--- a/install.py
+++ b/install.py
@@ -13,6 +13,7 @@ FILES_TO_COPY = {
     "eddy-ng/sensor_ldc1612_ng.c": "src",
     "probe_eddy_ng.py": "klippy/extras",
     "ldc1612_ng.py": "klippy/extras"
+
 }
 
 

--- a/install.py
+++ b/install.py
@@ -13,7 +13,6 @@ FILES_TO_COPY = {
     "eddy-ng/sensor_ldc1612_ng.c": "src",
     "probe_eddy_ng.py": "klippy/extras",
     "ldc1612_ng.py": "klippy/extras"
-
 }
 
 

--- a/probe_eddy_ng.py
+++ b/probe_eddy_ng.py
@@ -69,7 +69,6 @@ try:
 except ImportError:
     scipy = None
 
-
 # In this file, a couple of conventions are used (for sanity).
 # Variables are named according to:
 # - "height" is always a physical height as detected by the probe in mm
@@ -607,16 +606,12 @@ class ProbeEddy:
             self._temperature_sensor = self._printer.lookup_object(sensor_name)
             self._log_info(f"Found temperature sensor: {sensor_name}")
         except:
-            # Try alternative names
+            # Try alternative name
             try:
                 self._temperature_sensor = self._printer.lookup_object("temperature_sensor btt_eddy")
                 self._log_info("Found temperature sensor: temperature_sensor btt_eddy")
             except:
-                try:
-                    self._temperature_sensor = self._printer.lookup_object("temperature_sensor btt_eddy_mcu")
-                    self._log_info("Using MCU temperature as fallback: temperature_sensor btt_eddy_mcu")
-                except:
-                    self._log_warning("Temperature sensor not found for temperature profiles")
+                self._log_warning("Temperature sensor not found for temperature profiles")
 
     def _get_current_temperature(self):
         """Get current BTT Eddy sensor temperature"""
@@ -698,8 +693,6 @@ class ProbeEddy:
         self._tap_adjust_z = profile.tap_adjust_z
         if old_tap_adjust != self._tap_adjust_z:
             self._log_info(f"Changed tap_adjust_z from {old_tap_adjust:.6f} to {profile.tap_adjust_z:.6f}")
-
-        # calibration_version is not applied - handled by the system automatically
 
         # Reload calibration in probe
         if hasattr(self, '_load_calibration'):
@@ -2858,7 +2851,6 @@ class ProbeEddyEndstopWrapper:
     def _handle_homing_move_begin(self, hmove):
         if self not in hmove.get_mcu_endstops():
             return
-
         self._sampler = self.eddy.start_sampler()
         self._homing_in_progress = True
         # if we're doing a tap, we're already in the right position;


### PR DESCRIPTION
## Summary

  - Added comprehensive temperature profile system for BTT Eddy probe to handle thermal drift
  - Integrated temperature profiles into core eddy-ng classes for automatic profile switching
  - Implemented configuration-based profile management with automatic calibration data storage
  - Added new G-code command `EDDY_TEMP_PROFILE` for runtime profile management
  - Fixed issues with tap_adjust_z calibration workflow and `Z_OFFSET_APPLY_PROBE` command

### Key Features

  - **Automatic Profile Selection**: Profiles are automatically selected based on current sensor temperature
  - Calibration Data Storage: Each profile stores its own calibration data, drive currents, and tap_adjust_z values
  - Configuration Integration: Profiles are stored in printer.cfg and persist across restarts
  - **Runtime Management**: Full G-code interface for creating, selecting, and managing profiles
  - Temperature Tolerance: Configurable tolerance for profile switching hysteresis

### Configuration Example
```
  [probe_eddy_ng btt_eddy]
  temp_profiles_active: cold
  temp_profiles_tolerance: 2.0

  [eddy_temp_profile cold]
  temp_min: 15.0
  temp_max: 35.0
  tap_adjust_z: 0.025000

  [eddy_temp_profile hot]
  temp_min: 30.0
  temp_max: 50.0
  tap_adjust_z: 0.032000
```
### G-code Commands

  - `EDDY_TEMP_PROFILE ACTION=LIST` - List all profiles and current status
  - `EDDY_TEMP_PROFILE ACTION=CREATE NAME=profile_name MIN=temp MAX=temp` - Create new profile
  - `EDDY_TEMP_PROFILE ACTION=SELECT NAME=profile_name` - Select profile manually
  - `EDDY_TEMP_PROFILE ACTION=SELECT NAME=AUTO` - Auto-select based on temperature
  - `EDDY_TEMP_PROFILE ACTION=SAVE`- Save current calibration to active profile
  - `EDDY_TEMP_PROFILE ACTION=STATUS` - Show detailed status

### Important Notes

  - This code is currently undergoing testing on my printer
  - I would appreciate feedback from @vvuk regarding the future development direction of this PR
  - Temperature profiles become mandatory with this implementation. This is appropriate for enclosed printers but may be excessive for open-frame printers. I'm prepared to make temperature profiles optional if @vvuk  sees this as necessary.