### PR TITLE
Add a new sensor type 'ldc1612_internal_clk' to support the LDC1612 chip's internal oscillator

### DIFF
--- a/eddy-ng/sensor_ldc1612_ng.c
+++ b/eddy-ng/sensor_ldc1612_ng.c
@@ -65,6 +65,7 @@ enum {
 #define PRODUCT_BTT_EDDY 1
 #define PRODUCT_CARTOGRAPHER 2
 #define PRODUCT_MELLOW_FLY 3
+#define PRODUCT_LDC1612_INTERNAL_CLK 4
 
 // Chip registers
 #define REG_DATA0_MSB 0x00
@@ -348,6 +349,9 @@ config_ldc1612_ng(uint32_t oid, uint32_t i2c_oid, uint8_t product, int32_t intb_
         // pull that out on the python side.
         break;
 #endif
+    case PRODUCT_LDC1612_INTERNALL_CLK:
+        ld->sensor_cvt = 43400000.0f / (float)(1<<28);
+        break;
     default:
         shutdown("ldc1612_ng: unknown product");
     }

--- a/probe_eddy_ng.py
+++ b/probe_eddy_ng.py
@@ -437,6 +437,7 @@ class ProbeEddy:
             "btt_eddy": ldc1612_ng.LDC1612_ng,
             "cartographer": ldc1612_ng.LDC1612_ng,
             "mellow_fly": ldc1612_ng.LDC1612_ng,
+            "ldc1612_internal_clk": ldc1612_ng.LDC1612_ng,
         }
         sensor_type = config.getchoice("sensor_type", {s: s for s in sensors})
 
@@ -1116,7 +1117,7 @@ class ProbeEddy:
         )
 
         max_dc_increase = 0
-        if self._sensor_type == "ldc1612" or self._sensor_type == "btt_eddy":
+        if self._sensor_type == "ldc1612" or self._sensor_type == "btt_eddy" or self._sensor_type == "ldc1612_internal_clk":
             max_dc_increase = 5
         max_dc_increase = gcmd.get_int("MAX_DC_INCREASE", max_dc_increase, minval=0, maxval=30)
 


### PR DESCRIPTION
If some electronical DIYers want a cheap surface scanning product, they may want it to be simple and easy to maintain.
such as my project [LDC1612-EDDY](https://github.com/AiziChen/LDC1612-EDDY/tree/no-oscillator), it contains a branch `no-oscillator` that uses the LDC1612 internal oscillator.
That's why I added support for it. I tested it, and it works well for me.