### PR TITLE
Fix updated probe result being thrown away.

### DIFF
--- a/probe_eddy_ng.py
+++ b/probe_eddy_ng.py
@@ -2301,7 +2301,9 @@ class ProbeEddyScanningProbe:
                 bed_y = th_pos[1] + self.eddy.params.y_offset
                 res = manual_probe.ProbeResult(bed_x, bed_y, z_deviation,
                                                th_pos[0], th_pos[1], th_pos[2])
-                self._printer.send_event("probe:update_results", [res])
+                result_wrapper = [res]
+                self._printer.send_event("probe:update_results", result_wrapper)
+                res = result_wrapper[0]
             else:
                 res = [th_pos[0], th_pos[1], z]
                 self._printer.send_event("probe:update_results", res)


### PR DESCRIPTION
Because a temporary list was being used to pass the probe result, the updated probe result has never been returned to the `res` variable. This was especially noticeable with `axis_twist_compensation`. With this change the probe result updated by `axis_twist_compenstation` (and most probably by other extensions listening `probe:update_results`) are correctly incorporated.